### PR TITLE
add datetime based on city's selection

### DIFF
--- a/src/components/TimeAndLocation.jsx
+++ b/src/components/TimeAndLocation.jsx
@@ -1,10 +1,12 @@
-import React, { useEffect } from 'react'
+import React from 'react'
+import { dateTimetoLocalTime } from '../services/weatherService'
 
-function TimeAndLocation({weather: { name, country} }) {
+function TimeAndLocation({weather: { timezone, name, country} }) {
   return (
     <div>
       <div className="flex items-center justify-center my-6">
       <p className="text-white text-xl font-extralight">
+        {dateTimetoLocalTime(timezone)}
       </p>
     </div>
     

--- a/src/services/weatherService.js
+++ b/src/services/weatherService.js
@@ -16,6 +16,7 @@ const formatCurrentWeather = (data) => {
     main: {temp, feels_like, temp_max, temp_min, humidity},
     name,
     dt,
+    timezone,
     sys: {country, sunrise, sunset},
     weather,
     wind: {speed}
@@ -23,7 +24,7 @@ const formatCurrentWeather = (data) => {
 
   const {main: details, icon} = weather[0]
 
-  return {lat, lon, temp, feels_like, temp_max, temp_min, humidity, name, dt, country, sunrise, sunset, details, icon, speed}
+  return {lat, lon, temp, feels_like, temp_max, temp_min, humidity, name, dt, country, sunrise, sunset, details, icon, speed, timezone}
 }
 
 const formatForecastWeather = (data) => {
@@ -58,11 +59,13 @@ const getFormattedWeatherData = async searchParams => {
   return {...formattedCurrentWeather, ...formattedForecastWeather};
 };
 
+const dateTimetoLocalTime = (timezone) => DateTime.now().setZone(`UTC${timezone < 0 ? '' : '+'}${ timezone / 3600 }`).toFormat("cccc, dd LLL yyyy' | Local time:' hh:mm a");
+
 const dateTimeObject = time => DateTime.fromFormat(time, 'yyyy-MM-dd HH:mm:ss').toFormat('HH:mm');
 
 const iconUrlFromCode = code => `http://openweathermap.org/img/wn/${code}@2x.png`
 
 export default getFormattedWeatherData;
 
-export { dateTimeObject, iconUrlFromCode };
+export { dateTimeObject, iconUrlFromCode, dateTimetoLocalTime };
 


### PR DESCRIPTION
Add datetime based on city's selection by comparing the timezone offset second (converted to hours) with UTC; the free version of openweather API doesn't provide the zone in String (e.g. America/New_York) and hence the calculation